### PR TITLE
avoid returning WWW-Authenticate header if challenged by an ajax request

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,21 @@ public void ConfigureServices(IServiceCollection services)
             });
 }
 ```
+
+you can suppress the response WWW-Authenticate header (avoiding the browser to show a popup) for ajax requests by using a switch
+
+```c#
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddScoped<AuthenticationEvents>();
+
+    services
+        .AddAuthentication(BasicAuthenticationDefaults.AuthenticationScheme)
+        .AddBasicAuthentication(
+            options =>
+            {
+                options.Realm = "My Application";
+				options.SupressResponseHeaderWWWAuthenticateForAjaxRequests = true;
+            });
+}
+```

--- a/src/ZNetCS.AspNetCore.Authentication.Basic/BasicAuthenticationHandler.cs
+++ b/src/ZNetCS.AspNetCore.Authentication.Basic/BasicAuthenticationHandler.cs
@@ -165,11 +165,14 @@ namespace ZNetCS.AspNetCore.Authentication.Basic
             var realmHeader = new NameValueHeaderValue("realm", $"\"{this.Options.Realm}\"");
             this.Response.StatusCode = StatusCodes.Status401Unauthorized;
 
-            if (this.Request.Headers.TryGetValue("X-Requested-With", out var value))
+            if (this.Options.SupressResponseHeaderWWWAuthenticateForAjaxRequests)
             {
-                if (value == "XMLHttpRequest")
+                if (this.Request.Headers.TryGetValue(this.Options.AjaxRequestHeaderName, out var value))
                 {
-                    return Task.CompletedTask;
+                    if (value == this.Options.AjaxRequestHeaderValue)
+                    {
+                        return Task.CompletedTask;
+                    }
                 }
             }
 

--- a/src/ZNetCS.AspNetCore.Authentication.Basic/BasicAuthenticationHandler.cs
+++ b/src/ZNetCS.AspNetCore.Authentication.Basic/BasicAuthenticationHandler.cs
@@ -164,8 +164,16 @@ namespace ZNetCS.AspNetCore.Authentication.Basic
         {
             var realmHeader = new NameValueHeaderValue("realm", $"\"{this.Options.Realm}\"");
             this.Response.StatusCode = StatusCodes.Status401Unauthorized;
-            this.Response.Headers.Append(HeaderNames.WWWAuthenticate, $"{Basic} {realmHeader}");
 
+            if (this.Request.Headers.TryGetValue("X-Requested-With", out var value))
+            {
+                if (value == "XMLHttpRequest")
+                {
+                    return Task.CompletedTask;
+                }
+            }
+
+            this.Response.Headers.Append(HeaderNames.WWWAuthenticate, $"{Basic} {realmHeader}");
             return Task.CompletedTask;
         }
 

--- a/src/ZNetCS.AspNetCore.Authentication.Basic/BasicAuthenticationOptions.cs
+++ b/src/ZNetCS.AspNetCore.Authentication.Basic/BasicAuthenticationOptions.cs
@@ -24,6 +24,9 @@ namespace ZNetCS.AspNetCore.Authentication.Basic
     /// </summary>
     public class BasicAuthenticationOptions : AuthenticationSchemeOptions
     {
+        public const string DefaultAjaxRequestHeaderName = "X-Requested-With";
+        public const string DefaultAjaxRequestHeaderValue = "XMLHttpRequest";
+
         #region Constructors and Destructors
 
         /// <summary>
@@ -33,6 +36,8 @@ namespace ZNetCS.AspNetCore.Authentication.Basic
         {
             this.Realm = BasicAuthenticationDefaults.Realm;
             this.Events = new BasicAuthenticationEvents();
+            AjaxRequestHeaderName = DefaultAjaxRequestHeaderName;
+            AjaxRequestHeaderValue = DefaultAjaxRequestHeaderValue;
         }
 
         #endregion
@@ -72,6 +77,14 @@ namespace ZNetCS.AspNetCore.Authentication.Basic
         [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "OK")]
         public string Realm { get; set; }
 
+        /// <summary>
+        /// If enabled, it suppress sending the WWWAuthenticate response header when a request has the header (X-Requested-With,XMLHttpRequest)
+        /// </summary>
+        public bool SupressResponseHeaderWWWAuthenticateForAjaxRequests { get; set; }
+
+        public string AjaxRequestHeaderName { get; set; }
+
+        public string AjaxRequestHeaderValue { get; set; }
         #endregion
     }
 }

--- a/test/ZNetCS.AspNetCore.Authentication.BasicTests/AuthorizationTest.cs
+++ b/test/ZNetCS.AspNetCore.Authentication.BasicTests/AuthorizationTest.cs
@@ -274,6 +274,34 @@ namespace ZNetCS.AspNetCore.Authentication.BasicTests
             }
         }
 
+        /// <summary>
+        /// The unauthorized basic realm via ajax
+        /// </summary>
+        [TestMethod]
+        public async Task UnauthorizedMyRealmTestAjaxRequestSuppressed()
+        {
+            using (var server = new TestServer(WebHostBuilderHelper.CreateBuilder(o =>
+            {
+                o.Realm = "My realm";
+                o.SupressResponseHeaderWWWAuthenticateForAjaxRequests = true;
+            })))
+            {
+                using (HttpClient client = server.CreateClient())
+                {
+                    client.DefaultRequestHeaders.Add(Basic.BasicAuthenticationOptions.DefaultAjaxRequestHeaderName, Basic.BasicAuthenticationOptions.DefaultAjaxRequestHeaderValue);
+
+                    // Act
+                    HttpResponseMessage response = await client.GetAsync("api/test");
+
+                    // Assert
+                    AuthenticationHeaderValue wwwAuth = response.Headers.WwwAuthenticate.SingleOrDefault();
+
+                    Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode, "StatusCode != Unauthorized");
+                    Assert.IsNull(wwwAuth, "No header should be sent back on ajax request");
+                }
+            }
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Hi,
with this pull request we avoid to show a popup to users as consequence of an unauthenticated ajax request.